### PR TITLE
Project 1 Priority Scheduling

### DIFF
--- a/pintos/src/threads/synch.c
+++ b/pintos/src/threads/synch.c
@@ -200,6 +200,7 @@ lock_init (struct lock *lock)
 
   lock->holder = NULL;
   sema_init (&lock->semaphore, 1);
+  lock_priority = 0;
 }
 
 /* Acquires LOCK, sleeping until it becomes available if

--- a/pintos/src/threads/synch.c
+++ b/pintos/src/threads/synch.c
@@ -274,14 +274,6 @@ struct semaphore_elem
     struct semaphore semaphore;         /* This semaphore. */
   };
 
-/* new */
-struct lock_elem 
-  {
-    struct list_elem elem; 
-    struct lock lock;
-    int priority;
-  };
-
 /* Initializes condition variable COND.  A condition variable
    allows one piece of code to signal a condition and cooperating
    code to receive the signal and act upon it. */

--- a/pintos/src/threads/synch.c
+++ b/pintos/src/threads/synch.c
@@ -200,7 +200,6 @@ lock_init (struct lock *lock)
 
   lock->holder = NULL;
   sema_init (&lock->semaphore, 1);
-  lock_priority = 0;
 }
 
 /* Acquires LOCK, sleeping until it becomes available if
@@ -273,6 +272,14 @@ struct semaphore_elem
   {
     struct list_elem elem;              /* List element. */
     struct semaphore semaphore;         /* This semaphore. */
+  };
+
+/* new */
+struct lock_elem 
+  {
+    struct list_elem elem; 
+    struct lock lock;
+    int priority;
   };
 
 /* Initializes condition variable COND.  A condition variable

--- a/pintos/src/threads/synch.h
+++ b/pintos/src/threads/synch.h
@@ -22,7 +22,14 @@ struct lock
   {
     struct thread *holder;      /* Thread holding lock (for debugging). */
     struct semaphore semaphore; /* Binary semaphore controlling access. */
-    int priority; /* new */
+  };
+
+/* new */
+struct lock_elem 
+  {
+    struct list_elem elem; 
+    struct lock lock;
+    int priority;
   };
 
 void lock_init (struct lock *);

--- a/pintos/src/threads/synch.h
+++ b/pintos/src/threads/synch.h
@@ -22,6 +22,7 @@ struct lock
   {
     struct thread *holder;      /* Thread holding lock (for debugging). */
     struct semaphore semaphore; /* Binary semaphore controlling access. */
+    int priority; /* new */
   };
 
 void lock_init (struct lock *);

--- a/pintos/src/threads/thread.c
+++ b/pintos/src/threads/thread.c
@@ -346,7 +346,7 @@ thread_set_priority (int new_priority)
 {
   int old_priority = thread_current()->priority;
   thread_current()->priority = new_priority;
-
+  thread_current()->origin_priority = new_priority;
   if(new_priority < old_priority)
     thread_yield();
 }
@@ -476,6 +476,11 @@ init_thread (struct thread *t, const char *name, int priority)
   t->stack = (uint8_t *) t + PGSIZE;
   t->priority = priority;
   t->magic = THREAD_MAGIC;
+   /* new */
+  t->waking_ticks = 0;
+  t->origin_priority = priority;
+  lock_init(&t->acquiring_lock); 
+  list_init(&t->holding_locks);
 
   old_level = intr_disable ();
   list_push_back (&all_list, &t->allelem);

--- a/pintos/src/threads/thread.h
+++ b/pintos/src/threads/thread.h
@@ -100,7 +100,9 @@ struct thread
 
     /*new*/
     int64_t waking_ticks;
-
+    struct lock acquiring_lock; 
+    struct list holding_locks;
+    int origin_priority;
     /* Owned by thread.c. */
     unsigned magic;                     /* Detects stack overflow. */
 


### PR DESCRIPTION
Implemented origin priority, acquiring lock, holding locks to do priority donation.
origin priority have thread's original priority to do restore priority after lock release.
acquiring lock have thread's acquiring lock to do priority donation.
holding locks have thread's holding locks to change priority after lock release.